### PR TITLE
Classic and Cataclysm shaman fixes

### DIFF
--- a/LibDispel.lua
+++ b/LibDispel.lua
@@ -1102,11 +1102,13 @@ do
 			local cleanse = purify or CheckSpell(51886) -- Cleanse Spirit
 			local improvedCleanse = Cata and CheckTalentClassic(3, 14) -- Improved Cleanse Spirit
 			local toxins = Retail and CheckSpell(383013) or CheckSpell(526) -- Poison Cleansing Totem (Retail), Cure Toxins (Classic)
+			local cureDisease = Classic and CheckSpell(2870) -- Cure Disease
+			local diseaseTotem = Classic and CheckSpell(8170) -- Disease Cleansing Totem
 
 			DispelList.Magic = purify or (Cata and cleanse and improvedCleanse)
 			DispelList.Curse = cleanse
 			DispelList.Poison = toxins
-			DispelList.Disease = Classic and toxins
+			DispelList.Disease = cureDisease or diseaseTotem
 		elseif myClass == 'EVOKER' then
 			local naturalize = CheckSpell(360823) -- Naturalize (Preservation)
 			local expunge = CheckSpell(365585) -- Expunge (Devastation)

--- a/LibDispel.lua
+++ b/LibDispel.lua
@@ -4,11 +4,12 @@ local lib = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end
 
 local Retail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
-local Cata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
 local Classic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+local Cata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
 
 local next = next
 local CreateFrame = CreateFrame
+local GetTalentInfo = GetTalentInfo
 local IsPlayerSpell = IsPlayerSpell
 local IsSpellKnownOrOverridesKnown = IsSpellKnownOrOverridesKnown
 
@@ -1059,7 +1060,7 @@ do
 
 	local function CheckTalentClassic(tabIndex, talentIndex)
 		local _, _, _, _, rank = GetTalentInfo(tabIndex, talentIndex)
-		return rank > 0 or nil
+		return (rank and rank > 0) or nil
 	end
 
 	local function UpdateDispels(_, event, arg1)
@@ -1099,13 +1100,13 @@ do
 			DispelList.Disease = Retail and (IsPlayerSpell(390632) or CheckSpell(213634)) or not Retail and (CheckSpell(552) or CheckSpell(528)) -- Purify Disease / Abolish Disease / Cure Disease
 		elseif myClass == 'SHAMAN' then
 			local purify = Retail and CheckSpell(77130) -- Purify Spirit
-			local cleanse = purify or CheckSpell(51886) -- Cleanse Spirit
-			local improvedCleanse = Cata and CheckTalentClassic(3, 14) -- Improved Cleanse Spirit
+			local cleanse = purify or CheckSpell(51886) -- Cleanse Spirit (Retail/Cata)
+			local improvedCleanse = Cata and cleanse and CheckTalentClassic(3, 14) -- Improved Cleanse Spirit
 			local toxins = Retail and CheckSpell(383013) or CheckSpell(526) -- Poison Cleansing Totem (Retail), Cure Toxins (Classic)
 			local cureDisease = Classic and CheckSpell(2870) -- Cure Disease
 			local diseaseTotem = Classic and CheckSpell(8170) -- Disease Cleansing Totem
 
-			DispelList.Magic = purify or (Cata and cleanse and improvedCleanse)
+			DispelList.Magic = purify or improvedCleanse
 			DispelList.Curse = cleanse
 			DispelList.Poison = toxins
 			DispelList.Disease = cureDisease or diseaseTotem

--- a/LibDispel.lua
+++ b/LibDispel.lua
@@ -1,10 +1,11 @@
-local MAJOR, MINOR = "LibDispel-1.0", 6
+local MAJOR, MINOR = "LibDispel-1.0", 7
 assert(LibStub, MAJOR.." requires LibStub")
 local lib = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end
 
 local Retail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
-local Wrath = WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC
+local Cata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
+local Classic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 
 local next = next
 local CreateFrame = CreateFrame
@@ -1056,6 +1057,11 @@ do
 		end
 	end
 
+	local function CheckTalentClassic(tabIndex, talentIndex)
+		local _, _, _, _, rank = GetTalentInfo(tabIndex, talentIndex)
+		return rank > 0 or nil
+	end
+
 	local function UpdateDispels(_, event, arg1)
 		if event == 'CHARACTER_POINTS_CHANGED' and arg1 > 0 then
 			return -- Not interested in gained points from leveling
@@ -1094,12 +1100,13 @@ do
 		elseif myClass == 'SHAMAN' then
 			local purify = Retail and CheckSpell(77130) -- Purify Spirit
 			local cleanse = purify or CheckSpell(51886) -- Cleanse Spirit
-			local toxins = Retail and CheckSpell(383013) or CheckSpell(526) -- Poison Cleansing Totem (Retail), Cure Toxins (TBC/Classic)
+			local improvedCleanse = Cata and CheckTalentClassic(3, 14) -- Improved Cleanse Spirit
+			local toxins = Retail and CheckSpell(383013) or CheckSpell(526) -- Poison Cleansing Totem (Retail), Cure Toxins (Classic)
 
-			DispelList.Magic = purify
+			DispelList.Magic = purify or (Cata and cleanse and improvedCleanse)
 			DispelList.Curse = cleanse
-			DispelList.Poison = toxins or (not Retail and cleanse)
-			DispelList.Disease = not Retail and (cleanse or toxins)
+			DispelList.Poison = toxins
+			DispelList.Disease = Classic and toxins
 		elseif myClass == 'EVOKER' then
 			local naturalize = CheckSpell(360823) -- Naturalize (Preservation)
 			local expunge = CheckSpell(365585) -- Expunge (Devastation)
@@ -1133,7 +1140,7 @@ do
 		frame:RegisterUnitEvent('UNIT_PET', 'player')
 	end
 
-	if Wrath then
+	if Cata then
 		frame:RegisterEvent('PLAYER_TALENT_UPDATE')
 	elseif Retail then
 		frame:RegisterEvent('LEARNED_SPELL_IN_TAB')


### PR DESCRIPTION
I happened to notice the disease dispel conditions for classic seemed incorrect while fixing the cataclysm dispel types. I don't actually play classic, so if I'm missing something and the previous conditions were correct, feel free to exclude 9a9766ed75a1c6c7c2242f1eedb3688cedf8f1e6.